### PR TITLE
fix: allow nulls on context values

### DIFF
--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -29,12 +29,12 @@ class TelemetryContext {
   static const _applicationVersionKey = 'ai.application.ver';
 
   /// The application version to attach to telemetry items.
-  String get applicationVersion => _contextMap[_applicationVersionKey];
+  String? get applicationVersion => _contextMap[_applicationVersionKey];
 
   /// Setting will change the application version attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.application.ver` key on [TelemetryContext.properties].
-  set applicationVersion(String value) => _contextMap.setOrRemove(_applicationVersionKey, value);
+  set applicationVersion(String? value) => _contextMap.setOrRemove(_applicationVersionKey, value);
 
   /// Cloud-related properties to attach to telemetry items.
   final CloudContext cloud;
@@ -72,20 +72,20 @@ class CloudContext {
   static const _roleInstanceKey = '${_prefix}roleInstance';
 
   /// The cloud role to attach to telemetry items.
-  String get role => _contextMap[_roleKey];
+  String? get role => _contextMap[_roleKey];
 
   /// Setting will change the cloud role attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.cloud.role` key on [TelemetryContext.properties].
-  set role(String value) => _contextMap.setOrRemove(_roleKey, value);
+  set role(String? value) => _contextMap.setOrRemove(_roleKey, value);
 
   /// The cloud role instance to attach to telemetry items.
-  String get roleInstance => _contextMap[_roleInstanceKey];
+  String? get roleInstance => _contextMap[_roleInstanceKey];
 
   /// Setting will change the cloud role instance attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.cloud.roleInstance` key on [TelemetryContext.properties].
-  set roleInstance(String value) => _contextMap.setOrRemove(_roleInstanceKey, value);
+  set roleInstance(String? value) => _contextMap.setOrRemove(_roleInstanceKey, value);
 
   /// Remove cloud properties from the associated [TelemetryContext.properties].
   void clear() => _contextMap.removeWhere((key, dynamic value) => key.startsWith(_prefix));
@@ -105,53 +105,53 @@ class DeviceContext {
   static const _typeKey = '${_prefix}type';
 
   /// The device ID to attach to telemetry items.
-  String get id => _contextMap[_idKey];
+  String? get id => _contextMap[_idKey];
 
   /// Setting will change the device ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.device.id` key on [TelemetryContext.properties].
-  set id(String value) => _contextMap.setOrRemove(_idKey, value);
+  set id(String? value) => _contextMap.setOrRemove(_idKey, value);
 
   /// The device locale to attach to telemetry items.
-  String get locale => _contextMap[_localeKey];
+  String? get locale => _contextMap[_localeKey];
 
   /// Setting will change the device locale attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.device.locale` key on [TelemetryContext.properties].
-  set locale(String value) => _contextMap.setOrRemove(_localeKey, value);
+  set locale(String? value) => _contextMap.setOrRemove(_localeKey, value);
 
   /// The device model to attach to telemetry items.
-  String get model => _contextMap[_modelKey];
+  String? get model => _contextMap[_modelKey];
 
   /// Setting will change the devicemodel attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.device.model` key on [TelemetryContext.properties].
-  set model(String value) => _contextMap.setOrRemove(_modelKey, value);
+  set model(String? value) => _contextMap.setOrRemove(_modelKey, value);
 
   /// The device OEM name to attach to telemetry items.
-  String get oemName => _contextMap[_oemNameKey];
+  String? get oemName => _contextMap[_oemNameKey];
 
   /// Setting will change the device OEM name attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.device.eomName` key on [TelemetryContext.properties].
-  set oemName(String value) => _contextMap.setOrRemove(_oemNameKey, value);
+  set oemName(String? value) => _contextMap.setOrRemove(_oemNameKey, value);
 
   /// The device operating system version to attach to telemetry items.
-  String get osVersion => _contextMap[_osVersionKey];
+  String? get osVersion => _contextMap[_osVersionKey];
 
   /// Setting will change the device operating system version attached to telemetry items submitted with
   /// this context.
   ///
   /// This is a convenience for setting the `ai.device.osVersion` key on [TelemetryContext.properties].
-  set osVersion(String value) => _contextMap.setOrRemove(_osVersionKey, value);
+  set osVersion(String? value) => _contextMap.setOrRemove(_osVersionKey, value);
 
   /// The device type to attach to telemetry items.
-  String get type => _contextMap[_typeKey];
+  String? get type => _contextMap[_typeKey];
 
   /// Setting will change the device type attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.device.type` key on [TelemetryContext.properties].
-  set type(String value) => _contextMap.setOrRemove(_typeKey, value);
+  set type(String? value) => _contextMap.setOrRemove(_typeKey, value);
 
   /// Remove device properties from the associated [TelemetryContext.properties].
   void clear() => _contextMap.removeWhere((key, dynamic value) => key.startsWith(_prefix));
@@ -169,36 +169,36 @@ class LocationContext {
   static const _cityKey = '${_prefix}city';
 
   /// The location IP address to attach to telemetry items.
-  String get ip => _contextMap[_ipKey];
+  String? get ip => _contextMap[_ipKey];
 
   /// Setting will change the location IP address attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.location.ip` key on [TelemetryContext.properties].
-  set ip(String value) => _contextMap.setOrRemove(_ipKey, value);
+  set ip(String? value) => _contextMap.setOrRemove(_ipKey, value);
 
   /// The location country to attach to telemetry items.
-  String get country => _contextMap[_countryKey];
+  String? get country => _contextMap[_countryKey];
 
   /// Setting will change the location country attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.location.country` key on [TelemetryContext.properties].
-  set country(String value) => _contextMap.setOrRemove(_countryKey, value);
+  set country(String? value) => _contextMap.setOrRemove(_countryKey, value);
 
   /// The location province to attach to telemetry items.
-  String get province => _contextMap[_provinceKey];
+  String? get province => _contextMap[_provinceKey];
 
   /// Setting will change the location province attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.location.province` key on [TelemetryContext.properties].
-  set province(String value) => _contextMap.setOrRemove(_provinceKey, value);
+  set province(String? value) => _contextMap.setOrRemove(_provinceKey, value);
 
   /// The location city to attach to telemetry items.
-  String get city => _contextMap[_cityKey];
+  String? get city => _contextMap[_cityKey];
 
   /// Setting will change the location city attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.location.city` key on [TelemetryContext.properties].
-  set city(String value) => _contextMap.setOrRemove(_cityKey, value);
+  set city(String? value) => _contextMap.setOrRemove(_cityKey, value);
 
   /// Remove location properties from the associated [TelemetryContext.properties].
   void clear() => _contextMap.removeWhere((key, dynamic value) => key.startsWith(_prefix));
@@ -217,44 +217,44 @@ class OperationContext {
   static const _correlationVectorKey = '${_prefix}correlationVector';
 
   /// The operation ID to attach to telemetry items.
-  String get id => _contextMap[_idKey];
+  String? get id => _contextMap[_idKey];
 
   /// Setting will change the operation ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.operation.id` key on [TelemetryContext.properties].
-  set id(String value) => _contextMap.setOrRemove(_idKey, value);
+  set id(String? value) => _contextMap.setOrRemove(_idKey, value);
 
   /// The operation name to attach to telemetry items.
-  String get name => _contextMap[_nameKey];
+  String? get name => _contextMap[_nameKey];
 
   /// Setting will change the operation name attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.operation.name` key on [TelemetryContext.properties].
-  set name(String value) => _contextMap.setOrRemove(_nameKey, value);
+  set name(String? value) => _contextMap.setOrRemove(_nameKey, value);
 
   /// The operation parent ID to attach to telemetry items.
-  String get parentId => _contextMap[_parentIdKey];
+  String? get parentId => _contextMap[_parentIdKey];
 
   /// Setting will change the operation parent ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.operation.parentId` key on [TelemetryContext.properties].
-  set parentId(String value) => _contextMap.setOrRemove(_parentIdKey, value);
+  set parentId(String? value) => _contextMap.setOrRemove(_parentIdKey, value);
 
   /// The operation synthetic source to attach to telemetry items.
-  String get syntheticSource => _contextMap[_syntheticSourceKey];
+  String? get syntheticSource => _contextMap[_syntheticSourceKey];
 
   /// Setting will change the operation synthetic source attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.operation.syntheticSource` key on [TelemetryContext.properties].
-  set syntheticSource(String value) => _contextMap.setOrRemove(_syntheticSourceKey, value);
+  set syntheticSource(String? value) => _contextMap.setOrRemove(_syntheticSourceKey, value);
 
   /// The operation correlation vector to attach to telemetry items.
-  String get correlationVector => _contextMap[_correlationVectorKey];
+  String? get correlationVector => _contextMap[_correlationVectorKey];
 
   /// Setting will change the operation correlation vector attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.operation.correlationVector` key on [TelemetryContext.properties].
-  set correlationVector(String value) => _contextMap.setOrRemove(_correlationVectorKey, value);
+  set correlationVector(String? value) => _contextMap.setOrRemove(_correlationVectorKey, value);
 
   /// Remove operation properties from the associated [TelemetryContext.properties].
   void clear() => _contextMap.removeWhere((key, dynamic value) => key.startsWith(_prefix));
@@ -270,12 +270,12 @@ class SessionContext {
   static const _isFirstKey = '${_prefix}isFirst';
 
   /// The session ID to attach to telemetry items.
-  String get sessionId => _contextMap[_idKey];
+  String? get sessionId => _contextMap[_idKey];
 
   /// Setting will change the session ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.session.id` key on [TelemetryContext.properties].
-  set sessionId(String value) => _contextMap.setOrRemove(_idKey, value);
+  set sessionId(String? value) => _contextMap.setOrRemove(_idKey, value);
 
   /// The session "is first" flag to attach to telemetry items.
   bool get isFirst => _contextMap[_isFirstKey];
@@ -300,33 +300,33 @@ class UserContext {
   static const _authUserIdKey = '${_prefix}authUserId';
 
   /// The user account ID to attach to telemetry items.
-  String get accountId => _contextMap[_accountIdKey];
+  String? get accountId => _contextMap[_accountIdKey];
 
   /// Setting will change the user account ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.user.accountId` key on [TelemetryContext.properties].
-  set accountId(String value) => _contextMap.setOrRemove(_accountIdKey, value);
+  set accountId(String? value) => _contextMap.setOrRemove(_accountIdKey, value);
 
   /// The user ID to attach to telemetry items.
-  String get id => _contextMap[_userIdKey];
+  String? get id => _contextMap[_userIdKey];
 
   /// Setting will change the user ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.userId` key on [TelemetryContext.properties].
-  set id(String value) => _contextMap.setOrRemove(_userIdKey, value);
+  set id(String? value) => _contextMap.setOrRemove(_userIdKey, value);
 
   /// The user authenticated ID to attach to telemetry items.
-  String get authUserId => _contextMap[_authUserIdKey];
+  String? get authUserId => _contextMap[_authUserIdKey];
 
   /// Setting will change the user authenticated ID attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.user.authUserId` key on [TelemetryContext.properties].
-  set authUserId(String value) => _contextMap.setOrRemove(_authUserIdKey, value);
+  set authUserId(String? value) => _contextMap.setOrRemove(_authUserIdKey, value);
 
   /// Remove user properties from the associated [TelemetryContext.properties].
   void clear() => _contextMap.removeWhere((key, dynamic value) => key.startsWith(_prefix));
 }
 
 extension _MapExtensions<K, V> on Map<K, V> {
-  void setOrRemove(K key, V value) => value == null ? remove(key) : this[key] = value;
+  void setOrRemove(K key, V? value) => value == null ? remove(key) : this[key] = value;
 }

--- a/lib/src/context.dart
+++ b/lib/src/context.dart
@@ -278,12 +278,12 @@ class SessionContext {
   set sessionId(String? value) => _contextMap.setOrRemove(_idKey, value);
 
   /// The session "is first" flag to attach to telemetry items.
-  bool get isFirst => _contextMap[_isFirstKey];
+  bool? get isFirst => _contextMap[_isFirstKey];
 
   /// Setting will change the session "is first" flag attached to telemetry items submitted with this context.
   ///
   /// This is a convenience for setting the `ai.session.isFirst` key on [TelemetryContext.properties].
-  set isFirst(bool value) => _contextMap.setOrRemove(_isFirstKey, value);
+  set isFirst(bool? value) => _contextMap.setOrRemove(_isFirstKey, value);
 
   /// Remove session properties from the associated [TelemetryContext.properties].
   void clear() => _contextMap.removeWhere((key, dynamic value) => key.startsWith(_prefix));
@@ -328,5 +328,5 @@ class UserContext {
 }
 
 extension _MapExtensions<K, V> on Map<K, V> {
-  void setOrRemove(K key, V? value) => value == null ? remove(key) : this[key] = value;
+  void setOrRemove(K key, V value) => value == null ? remove(key) : this[key] = value;
 }

--- a/test/context_test.dart
+++ b/test/context_test.dart
@@ -10,6 +10,7 @@ void main() {
   _operationContext();
   _sessionContext();
   _userContext();
+  _removingProperties();
 }
 
 void _verifyContextData({
@@ -31,13 +32,6 @@ void _cloudContext() {
           ..cloud.role = 'role'
           ..cloud.roleInstance = 'role instance',
         expectedJson: '{"ai.cloud.role":"role","ai.cloud.roleInstance":"role instance"}',
-      );
-      _verifyContextData(
-        context: TelemetryContext()
-          ..cloud.role = 'role'
-          ..cloud.roleInstance = 'role instance'
-          ..cloud.role = null,
-        expectedJson: '{"ai.cloud.roleInstance":"role instance"}',
       );
     },
   );
@@ -124,4 +118,18 @@ void _userContext() {
       );
     },
   );
+}
+
+void _removingProperties() {
+  test('removing properties', () {
+    _verifyContextData(
+      context: TelemetryContext()
+        ..cloud.roleInstance = 'role instance'
+        ..cloud.role = 'role'
+        ..session.isFirst = true
+        ..cloud.role = null
+        ..session.isFirst = null,
+      expectedJson: '{"ai.cloud.roleInstance":"role instance"}',
+    );
+  });
 }

--- a/test/context_test.dart
+++ b/test/context_test.dart
@@ -32,6 +32,13 @@ void _cloudContext() {
           ..cloud.roleInstance = 'role instance',
         expectedJson: '{"ai.cloud.role":"role","ai.cloud.roleInstance":"role instance"}',
       );
+      _verifyContextData(
+        context: TelemetryContext()
+          ..cloud.role = 'role'
+          ..cloud.roleInstance = 'role instance'
+          ..cloud.role = null,
+        expectedJson: '{"ai.cloud.roleInstance":"role instance"}',
+      );
     },
   );
 }


### PR DESCRIPTION
The typing on context objects is currently too strict, treating every attribute as non-null. This has a few important consequences:

- Attempting to read a value before it is assigned causes a type error
- It's not possible to actually delete anything

This patch just changes all context value types to `String?` and includes a single test to ensure that `_contextMap.setOrRemove()` actually removes a key when its value is `null`.
