### PR TITLE
Fix compatibility with Flutter 3.10 and 3.13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   http: '>=0.13.6 <2.0.0'
   logging: ^1.2.0
   meta: ^1.9.1
-  stack_trace: ^1.11.1
+  stack_trace: ^1.11.0
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
This PR downgrade `stack_trace` to `1.11.0` to make package compatible with Flutter 3.10 and Flutter 3.13

Closes #41