### PR TITLE
Connection string support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ import 'package:azure_application_insights/azure_application_insights.dart';
 
 ## How?
 
-The only piece of information you need to integrate with Application Insights is your instrumentation key, which you can find inside the Azure portal. Open your Application Insights resource and look in the **Overview** tab.
+The only piece of information you need to integrate with Application Insights is your connection string, which you can find inside the Azure portal. Open your Application Insights resource and look in the **Overview** tab.
 
-Once you have your instrumentation key, you can construct a `TelemetryClient` as follows:
+Once you have your connection string, you can construct a `TelemetryClient` as follows:
 
 ```dart
 final processor = BufferedProcessor(
   next: TransmissionProcessor(
-    instrumentationKey: instrumentationKey,
+    connectionString: connectionString,
     httpClient: client,
     timeout: const Duration(seconds: 10),
   ),
@@ -39,9 +39,6 @@ final telemetryClient = TelemetryClient(
   processor: processor,
 );
 ```
-
-> NOTE: depending on your Azure environment, you may also wish to override the default ingestion endpoint. To do this,
-> provide a value for the `ingestionEndpoint` parameter when creating a `TransmissionProcessor`.
 
 This is a typical setup where telemetry items are buffered before being transmitted. Depending on your processing needs, you may have a need for more than one `TelemetryClient` in your application. For example, you might have one `TelemetryClient` that buffers telemetry items and is used for all telemetry other than errors, and a second that does not buffer and is used only to submit errors as promptly as possible. Please review the example code and API docs for alternative configurations.
 

--- a/example/azure_application_insights_example.dart
+++ b/example/azure_application_insights_example.dart
@@ -3,13 +3,13 @@
 import 'package:azure_application_insights/azure_application_insights.dart';
 import 'package:http/http.dart';
 
-// Copy and paste your Application Insights instrumentation key from the Azure portal.
-const instrumentationKey = 'TODO';
+// Copy and paste your Application Insights connection string from the Azure portal.
+const connectionString = 'TODO';
 
 Future<void> main() async {
-  if (instrumentationKey == 'TODO') {
+  if (connectionString == 'TODO') {
     print(
-      'Before running this example, you must provide your Application Insights instrumentation key by copying it into the code.',
+      'Before running this example, you must provide your Application Insights connection string by copying it into the code.',
     );
     return;
   }
@@ -27,7 +27,7 @@ Future<void> _sendTelemetry() async {
     // forwarding them on for transmission.
     final processor = BufferedProcessor(
       next: TransmissionProcessor(
-        instrumentationKey: instrumentationKey,
+        connectionString: connectionString,
         // You can inject your own HTTP middleware to adjust the behavior of HTTP communications, such as automatically
         // retrying or caching failed requests.
         httpClient: client,

--- a/lib/src/connection_string.dart
+++ b/lib/src/connection_string.dart
@@ -1,0 +1,168 @@
+/// Represents a parsed connection string, exposing only the information we actually care about.
+class ConnectionString {
+  ConnectionString({
+    required this.instrumentationKey,
+    required this.ingestionEndpoint,
+    required this.endpointSuffix,
+    required this.location,
+  });
+
+  final String instrumentationKey;
+  final String? ingestionEndpoint;
+  final String? endpointSuffix;
+  final String? location;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ConnectionString &&
+      instrumentationKey == other.instrumentationKey &&
+      ingestionEndpoint == other.ingestionEndpoint &&
+      endpointSuffix == other.endpointSuffix &&
+      location == other.location;
+
+  @override
+  int get hashCode => Object.hash(
+        instrumentationKey,
+        ingestionEndpoint,
+        endpointSuffix,
+        location,
+      );
+}
+
+/// Parse [connectionString] into a [ConnectionString], throwing if it is invalid.
+///
+/// See https://learn.microsoft.com/en-us/azure/azure-monitor/app/sdk-connection-string?tabs=dotnet5#syntax
+ConnectionString parseConnectionString(String connectionString) {
+  String getRequiredEntry(Map<String, String> entries, String entryKey) {
+    final maybeValue = entries[entryKey];
+
+    if (maybeValue == null) {
+      throw UnsupportedError(
+          "Connection string does not contain required entry, '$entryKey': $connectionString");
+    }
+
+    return maybeValue;
+  }
+
+  if (connectionString.isEmpty) {
+    throw UnsupportedError('Connection string cannot be an empty string');
+  }
+
+  final seenKeys = <String>{};
+
+  final mapEntries = connectionString
+      .split(';')
+      .where((s) => s.isNotEmpty)
+      .map((potentialKeyValuePair) {
+    final keyValuePair = potentialKeyValuePair.split('=');
+
+    if (keyValuePair.length != 2) {
+      throw UnsupportedError(
+          "Connection string contains portion '$potentialKeyValuePair', which cannot be parsed. Expected format is key=value");
+    }
+
+    final key = keyValuePair[0];
+
+    if (seenKeys.contains(key)) {
+      throw UnsupportedError('Connection string contains duplicate key, $key');
+    }
+
+    seenKeys.add(key);
+
+    final value = keyValuePair[1];
+    return MapEntry(key, value);
+  });
+
+  final map = Map.fromEntries(mapEntries);
+  final instrumentationKey = getRequiredEntry(map, 'InstrumentationKey');
+
+  return ConnectionString(
+    instrumentationKey: instrumentationKey,
+    ingestionEndpoint: map['IngestionEndpoint'],
+    endpointSuffix: map['EndpointSuffix'],
+    location: map['Location'],
+  );
+}
+
+extension ParsedConnectionStringExtensions on ConnectionString {
+  /// Get the URI to which telemetry events should be sent for ingestion into App Insights, given the connection string.
+  ///
+  /// Based on logic in .NET SDK: Microsoft.ApplicationInsights.Extensibility.Implementation.Endpoints.EndpointProvider.GetEndpoint
+  Uri getIngestionEndpoint() {
+    String? processAndValidateLocation(String? location) {
+      if (location == null) {
+        return null;
+      }
+
+      final trimmedLocation = location.trim().trimEnd('.');
+
+      if (!trimmedLocation.everyCodeUnit(
+          (codeUnit) => codeUnit.isDigit() || codeUnit.isLetter())) {
+        throw UnsupportedError(
+            'Location value in connection string is invalid because it contains characters that are not either letters or digits: $location');
+      }
+
+      return '$trimmedLocation.';
+    }
+
+    // 1. Check for explicit ingestion endpoint in connection string
+    final localIngestionEndpoint = ingestionEndpoint;
+
+    if (localIngestionEndpoint != null) {
+      final uri = Uri.tryParse(localIngestionEndpoint);
+
+      if (uri == null || !uri.isAbsolute) {
+        throw UnsupportedError(
+            'IngestionEndpoint value in connection string is not a valid URI: $localIngestionEndpoint');
+      }
+
+      return uri;
+    }
+
+    // 2. Check for endpoint suffix with optional location
+    final localEndpointSuffix = endpointSuffix;
+
+    if (localEndpointSuffix != null) {
+      final endpointSuffix = localEndpointSuffix.trim().trimStart('.');
+      const endpointPrefix = 'dc';
+      final processedAndValidatedLocation =
+          processAndValidateLocation(location);
+
+      final host =
+          '${processedAndValidatedLocation ?? ''}$endpointPrefix.$endpointSuffix';
+      return Uri(
+        scheme: "https",
+        host: host,
+      );
+    }
+
+    // 3. Use default (classic) endpoint
+    return Uri.parse('https://dc.services.visualstudio.com/');
+  }
+}
+
+extension _StringExtensions on String {
+  String trimStart(String charactersToRemove) {
+    final String escapedChars = RegExp.escape(charactersToRemove);
+    final RegExp regex = RegExp('^[$escapedChars]+');
+    final String newStr = replaceAll(regex, '').trim();
+    return newStr;
+  }
+
+  String trimEnd(String charactersToRemove) {
+    final String escapedChars = RegExp.escape(charactersToRemove);
+    final RegExp regex = RegExp('[$escapedChars]+\$');
+    final String newStr = replaceAll(regex, '').trim();
+    return newStr;
+  }
+
+  bool everyCodeUnit(bool Function(int ch) test) => codeUnits.every(test);
+}
+
+extension _CodeUnitExtensions on int {
+  bool isDigit() => (this ^ 0x30) <= 9;
+
+  bool isLetter() =>
+      // Only checking Latin characters here - presumably that will suffice for our purposes.
+      (this >= 65 && this <= 90) || (this >= 97 && this <= 122);
+}

--- a/lib/src/http.dart
+++ b/lib/src/http.dart
@@ -59,6 +59,7 @@ class TelemetryHttpClient extends BaseClient {
         .where((e) => appendHeader(e.key))
         .map((e) => '${e.key}=${e.value}')
         .join(',');
+
     telemetryClient.trackDependency(
       name: request.url.path.isEmpty ? '/' : request.url.path,
       id: _generateRequestId(),

--- a/test/connection_string_test.dart
+++ b/test/connection_string_test.dart
@@ -1,0 +1,340 @@
+import 'package:azure_application_insights/src/connection_string.dart';
+import 'package:test/test.dart';
+
+void main() {
+  _parseFailures();
+  _parseSuccesses();
+
+  _ingestionEndpointFailures();
+  _ingestionEndpointSuccesses();
+}
+
+void _parseFailures() {
+  group(
+    'Parse failures',
+    () {
+      test(
+        'cannot parse empty string',
+        () {
+          expect(
+            () => parseConnectionString(''),
+            throwsA(
+              const TypeMatcher<UnsupportedError>().having(
+                (e) => e.message,
+                'message',
+                equals('Connection string cannot be an empty string'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'cannot parse invalid key/value pair syntax',
+        () {
+          void doVerify({
+            required String connectionString,
+            required String expectedFaultyKeyValuePair,
+          }) {
+            expect(
+              () => parseConnectionString(connectionString),
+              throwsA(
+                const TypeMatcher<UnsupportedError>().having(
+                  (e) => e.message,
+                  'message',
+                  equals(
+                      "Connection string contains portion '$expectedFaultyKeyValuePair', which cannot be parsed. Expected format is key=value"),
+                ),
+              ),
+            );
+          }
+
+          doVerify(
+            connectionString: 'foo<-bar',
+            expectedFaultyKeyValuePair: 'foo<-bar',
+          );
+          doVerify(
+            connectionString: 'a=b;c=d;e;f=g',
+            expectedFaultyKeyValuePair: 'e',
+          );
+        },
+      );
+
+      test(
+        'cannot parse when there are duplicate keys',
+        () {
+          void doVerify({
+            required String connectionString,
+            required String expectedDuplicateKey,
+          }) {
+            expect(
+              () => parseConnectionString(connectionString),
+              throwsA(
+                const TypeMatcher<UnsupportedError>().having(
+                  (e) => e.message,
+                  'message',
+                  equals(
+                      'Connection string contains duplicate key, $expectedDuplicateKey'),
+                ),
+              ),
+            );
+          }
+
+          doVerify(
+            connectionString: 'a=b;a=c',
+            expectedDuplicateKey: 'a',
+          );
+          doVerify(
+            connectionString: 'a=b;c=d;a=d',
+            expectedDuplicateKey: 'a',
+          );
+        },
+      );
+
+      test(
+        'cannot parse if instrumentation key is missing',
+        () {
+          void doVerify({required String connectionString}) {
+            expect(
+              () => parseConnectionString(connectionString),
+              throwsA(
+                const TypeMatcher<UnsupportedError>().having(
+                  (e) => e.message,
+                  'message',
+                  equals(
+                      "Connection string does not contain required entry, 'InstrumentationKey': $connectionString"),
+                ),
+              ),
+            );
+          }
+
+          doVerify(
+            connectionString: 'a=b',
+          );
+          doVerify(
+            connectionString: 'a=b;c=d;e=f',
+          );
+        },
+      );
+    },
+  );
+}
+
+void _parseSuccesses() {
+  group(
+    'Parse successes',
+    () {
+      test(
+        'simple, instrumentation key only',
+        () {
+          void doVerify({
+            required String connectionString,
+            required String expectedInstrumentationKey,
+          }) {
+            final result = parseConnectionString(connectionString);
+            expect(result.instrumentationKey, expectedInstrumentationKey);
+          }
+
+          doVerify(
+            connectionString: 'InstrumentationKey=a',
+            expectedInstrumentationKey: 'a',
+          );
+          doVerify(
+            connectionString: 'InstrumentationKey=bar',
+            expectedInstrumentationKey: 'bar',
+          );
+          doVerify(
+            connectionString: 'InstrumentationKey=bar;',
+            expectedInstrumentationKey: 'bar',
+          );
+          doVerify(
+            connectionString: ';InstrumentationKey=bar;',
+            expectedInstrumentationKey: 'bar',
+          );
+          doVerify(
+            connectionString: 'InstrumentationKey= b a r ',
+            expectedInstrumentationKey: ' b a r ',
+          );
+        },
+      );
+      test(
+        'complex, more than just instrumentation key',
+        () {
+          void doVerify({
+            required String connectionString,
+            required ConnectionString expected,
+          }) {
+            final result = parseConnectionString(connectionString);
+            expect(result, expected);
+          }
+
+          doVerify(
+            connectionString: 'InstrumentationKey=whatever;a=b;c=d;e=f',
+            expected: ConnectionString(
+              instrumentationKey: 'whatever',
+              ingestionEndpoint: null,
+              endpointSuffix: null,
+              location: null,
+            ),
+          );
+          doVerify(
+            connectionString:
+                'InstrumentationKey=whatever;this=isignored;IngestionEndpoint=someexplicitendpoint',
+            expected: ConnectionString(
+              instrumentationKey: 'whatever',
+              ingestionEndpoint: 'someexplicitendpoint',
+              endpointSuffix: null,
+              location: null,
+            ),
+          );
+          doVerify(
+            connectionString:
+                'InstrumentationKey=mykey;IngestionEndpoint=some.where;EndpointSuffix=au;Location=brisbane',
+            expected: ConnectionString(
+              instrumentationKey: 'mykey',
+              ingestionEndpoint: 'some.where',
+              endpointSuffix: 'au',
+              location: 'brisbane',
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+void _ingestionEndpointFailures() {
+  group(
+    'Ingestion endpoint failures',
+    () {
+      test(
+        'invalid ingestion endpoint',
+        () {
+          final parsedConnectionString = parseConnectionString(
+              'InstrumentationKey=a;IngestionEndpoint=this cannot work');
+          expect(
+            () => parsedConnectionString.getIngestionEndpoint(),
+            throwsA(
+              const TypeMatcher<UnsupportedError>().having(
+                (e) => e.message,
+                'message',
+                equals(
+                    'IngestionEndpoint value in connection string is not a valid URI: this cannot work'),
+              ),
+            ),
+          );
+        },
+      );
+
+      test(
+        'invalid location',
+        () {
+          final parsedConnectionString = parseConnectionString(
+              'InstrumentationKey=a;EndpointSuffix=au;Location=nope!');
+          expect(
+            () => parsedConnectionString.getIngestionEndpoint(),
+            throwsA(
+              const TypeMatcher<UnsupportedError>().having(
+                (e) => e.message,
+                'message',
+                equals(
+                    'Location value in connection string is invalid because it contains characters that are not either letters or digits: nope!'),
+              ),
+            ),
+          );
+        },
+      );
+    },
+  );
+}
+
+void _ingestionEndpointSuccesses() {
+  group(
+    'Ingestion endpoint successes',
+    () {
+      void doVerify({
+        required String connectionString,
+        required Uri expected,
+      }) {
+        final parsedConnectionString = parseConnectionString(connectionString);
+        final result = parsedConnectionString.getIngestionEndpoint();
+        expect(result, expected);
+      }
+
+      test(
+        'explicit ingestion endpoint in connection string',
+        () {
+          doVerify(
+            connectionString:
+                'InstrumentationKey=a;IngestionEndpoint=https://somewhere.com/whatever',
+            expected: Uri.parse('https://somewhere.com/whatever'),
+          );
+          doVerify(
+            connectionString:
+                'InstrumentationKey=a;IngestionEndpoint=https://australiaeast-1.in.applicationinsights.azure.com/',
+            expected: Uri.parse(
+                'https://australiaeast-1.in.applicationinsights.azure.com/'),
+          );
+        },
+      );
+
+      test(
+        'endpoint suffix without location',
+        () {
+          doVerify(
+            connectionString: 'InstrumentationKey=a;EndpointSuffix=au',
+            expected: Uri.parse('https://dc.au'),
+          );
+          doVerify(
+            connectionString: 'InstrumentationKey=a;EndpointSuffix=.au',
+            expected: Uri.parse('https://dc.au'),
+          );
+          doVerify(
+            connectionString: 'InstrumentationKey=a;EndpointSuffix=....foo',
+            expected: Uri.parse('https://dc.foo'),
+          );
+          doVerify(
+            connectionString: 'InstrumentationKey=a;EndpointSuffix=  ....foo  ',
+            expected: Uri.parse('https://dc.foo'),
+          );
+        },
+      );
+
+      test(
+        'endpoint suffix with location',
+        () {
+          doVerify(
+            connectionString:
+                'InstrumentationKey=a;EndpointSuffix=au;Location=brisbane',
+            expected: Uri.parse('https://brisbane.dc.au'),
+          );
+          doVerify(
+            connectionString:
+                'InstrumentationKey=a;EndpointSuffix=au;Location=brisbane.',
+            expected: Uri.parse('https://brisbane.dc.au'),
+          );
+          doVerify(
+            connectionString:
+                'InstrumentationKey=a;EndpointSuffix=au;Location=brisbane...',
+            expected: Uri.parse('https://brisbane.dc.au'),
+          );
+          doVerify(
+            connectionString:
+                'InstrumentationKey=a;EndpointSuffix=au;Location=  adelaide...  ',
+            expected: Uri.parse('https://adelaide.dc.au'),
+          );
+        },
+      );
+
+      test(
+        'fallback to default endpoint',
+        () {
+          doVerify(
+            connectionString: 'InstrumentationKey=a',
+            expected: Uri.parse('https://dc.services.visualstudio.com/'),
+          );
+        },
+      );
+    },
+  );
+}

--- a/test/processing_test.dart
+++ b/test/processing_test.dart
@@ -160,7 +160,7 @@ void _transmissionProcessor() {
         () {
           final httpClient = MockClient();
           final sut = TransmissionProcessor(
-            instrumentationKey: 'key',
+            connectionString: 'InstrumentationKey=key',
             httpClient: httpClient,
             timeout: const Duration(seconds: 10),
           );
@@ -195,7 +195,7 @@ void _transmissionProcessor() {
           final httpClient = MockClient();
           final next = MockProcessor();
           final sut = TransmissionProcessor(
-            instrumentationKey: 'key',
+            connectionString: 'InstrumentationKey=key',
             httpClient: httpClient,
             timeout: const Duration(seconds: 10),
             next: next,


### PR DESCRIPTION
Switch the telemetry processor to using connection strings rather than instrumentation key. The latter is being phased out by Microsoft.

🚨🚨🚨 This is a breaking change, but easy for clients to fix 🚨🚨🚨