### PR TITLE
feat(error exposure): Integrated onError() callback in TransmissionPr…

### DIFF
--- a/lib/src/processing.dart
+++ b/lib/src/processing.dart
@@ -129,6 +129,7 @@ class TransmissionProcessor implements Processor {
     required this.timeout,
     Logger? logger,
     this.next,
+    this.onError,
   })  : logger = logger ?? Logger('TransmissionProcessor'),
         _outstandingFutures = <Future<void>>{} {
     _parsedConnectionString = parseConnectionString(connectionString);
@@ -136,6 +137,12 @@ class TransmissionProcessor implements Processor {
     _ingestionEndpoint =
         ingestionEndpoint.replace(path: '${ingestionEndpoint.path}/v2/track');
   }
+
+  final void Function(
+    List<ContextualTelemetryItem> contextualTelemetryItems,
+    int? responseStatusCode,
+    Object? exception,
+  )? onError;
 
   @override
   final Processor? next;
@@ -204,9 +211,11 @@ class TransmissionProcessor implements Processor {
       final result = response.statusCode >= 200 && response.statusCode < 300;
 
       if (!result) {
+        onError?.call(contextualTelemetry, response.statusCode, null);
         logger.severe('Failed to submit telemetry: ${response.statusCode}');
       }
     } on Object catch (e) {
+      onError?.call(contextualTelemetry, null, e);
       logger.warning('Failed to submit telemetry: $e');
     }
   }

--- a/test/processing_test.dart
+++ b/test/processing_test.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: cascade_invocations
 
 import 'package:azure_application_insights/azure_application_insights.dart';
+import 'package:http/http.dart';
 import 'package:mockito/mockito.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
@@ -216,6 +217,96 @@ void _transmissionProcessor() {
                   contextualTelemetryItems:
                       anyNamed('contextualTelemetryItems')))
               .called(1);
+        },
+      );
+
+      test(
+        'onError() callback receives the response status code when the HttpClient gives failure status code in TransmissionProcessor',
+        () {
+          void onError(
+            List<ContextualTelemetryItem> contextualTelemetryItems,
+            int? responseStatusCode,
+            Object? exception,
+          ) {
+            final eventName = (contextualTelemetryItems
+                    .firstOrNull?.telemetryItem as EventTelemetryItem?)
+                ?.name;
+
+            // Validating the data received from processor in onError() callback
+            expect(eventName, 'mock event');
+            expect(responseStatusCode, 400);
+          }
+
+          final httpClient = MockClient();
+          final sut = TransmissionProcessor(
+            connectionString: 'InstrumentationKey=key',
+            httpClient: httpClient,
+            timeout: const Duration(seconds: 10),
+            onError: onError,
+          );
+
+          when(httpClient.post(
+            any,
+            body: anyNamed('body'),
+          )).thenAnswer((_) async => Response('', 400));
+
+          sut.process(
+            contextualTelemetryItems: [
+              ContextualTelemetryItem(
+                telemetryItem: EventTelemetryItem(
+                  name: 'mock event',
+                  timestamp: DateTime.utc(2020, 10, 26),
+                ),
+                context: TelemetryContext(),
+              ),
+            ],
+          );
+        },
+      );
+
+      test(
+        'onError() callback receives the exception object when the HttpClient throws exception during API call in TransmissionProcessor',
+        () {
+          final mockException = Exception('mock exception');
+
+          void onError(
+            List<ContextualTelemetryItem> contextualTelemetryItems,
+            int? responseStatusCode,
+            Object? exception,
+          ) {
+            final eventName = (contextualTelemetryItems
+                    .firstOrNull?.telemetryItem as EventTelemetryItem?)
+                ?.name;
+
+            // Validating the data received from processor in onError() callback
+            expect(eventName, 'mock event');
+            expect(exception, mockException);
+          }
+
+          final httpClient = MockClient();
+          final sut = TransmissionProcessor(
+            connectionString: 'InstrumentationKey=key',
+            httpClient: httpClient,
+            timeout: const Duration(seconds: 10),
+            onError: onError,
+          );
+
+          when(httpClient.post(
+            any,
+            body: anyNamed('body'),
+          )).thenThrow(mockException);
+
+          sut.process(
+            contextualTelemetryItems: [
+              ContextualTelemetryItem(
+                telemetryItem: EventTelemetryItem(
+                  name: 'mock event',
+                  timestamp: DateTime.utc(2020, 10, 26),
+                ),
+                context: TelemetryContext(),
+              ),
+            ],
+          );
         },
       );
     },


### PR DESCRIPTION
- Errors can occur while sending data on Azure Application Insight servers.
- Right now, Logger class reports the error details but doesn't tell the telemetry details. Also, the error detail isn't reported in its true reported form.
- SDK must expose a way to let the client application know about the error along with their associated **telemetry details**.
- onError() callback is introduced in TransmissionProcess to provide this capability.